### PR TITLE
Reap the child process if there's an error during setup

### DIFF
--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -367,6 +367,9 @@ module Subprocess
       begin
         e = Marshal.load(control_r)
         e = "Unknown Failure" unless e.is_a?(Exception) || e.is_a?(String)
+        # Because we're throwing an exception and not returning a
+        # Process, we need to make sure the child gets reaped
+        wait
         raise e
       rescue EOFError # Nothing to read? Great!
       ensure


### PR DESCRIPTION
Previously, if the child process failed to, say, exec (e.g. because of a non-existent executable), nothing would ever reap the child process.

@zenazn Any thoughts? I think I saw a bug of this form in action, but I'm not positive.
