### PR TITLE
Fix dup/close behavior

### DIFF
--- a/test/test_subprocess.rb
+++ b/test/test_subprocess.rb
@@ -136,20 +136,6 @@ describe Subprocess do
       tmp.delete
     end
 
-    it 'makes a private copy of IOs' do
-      f = File.open(__FILE__)
-      tmp = Tempfile.new('test')
-      Subprocess.check_call(['cat'], :stdin => f, :stdout => tmp.open)
-      f.read.must_equal(tmp.read)
-    end
-
-    it 'makes a private copy of fds' do
-      f = File.open(__FILE__)
-      tmp = Tempfile.new('test')
-      Subprocess.check_call(['cat'], :stdin => f.fileno, :stdout => tmp.fileno)
-      f.read.must_equal(tmp.read)
-    end
-
     it 'opens pipes for communication' do
       Subprocess.check_call(['cat'], :stdin => Subprocess::PIPE,
                             :stdout => Subprocess::PIPE) do |p|


### PR DESCRIPTION
This commit reverts 5ad3c3c9f787177b9313605ef05e1b6511224b69 and fixes
the bug it was originally attempting to fix.

As of 5ad3c3c9f787177b9313605ef05e1b6511224b69, we dup IOs and file
descriptors passed to Subprocess. This was to work around an issue where
Subprocess would close files passed to it. However, the fact that
Subprocess closed these files was the actual bug, and the dup'ing
produced all kinds of undesirable behavior.

This change reverts the dup'ing behavior, but instead fixes the bug
where Subprocess would close file descriptors you passed it, making the
dup'ing behavior unnecessary in the first place.
