### PR TITLE
Use Travis CI to test the codebase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+  - 1.8.7
+  - 1.9.2
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+script: rake test

--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,2 @@
+source 'https://rubygems.org'
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Subprocess
-==========
+# Subprocess [![Build Status](https://travis-ci.org/stripe/subprocess.svg?branch=master)](https://travis-ci.org/stripe/subprocess)
 
 ![Jacques Cousteau Submarine](http://i.imgur.com/lmej24F.jpg)
 


### PR DESCRIPTION
I added `rubygems.org` to Gemfile to make `bundle install` work. The
README now contains a Travis CI build status badge.
