### PR TITLE
Add missing require of fileutils

### DIFF
--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -1,3 +1,4 @@
+require 'fileutils'
 require 'thread'
 require 'set'
 

--- a/lib/subprocess/version.rb
+++ b/lib/subprocess/version.rb
@@ -1,3 +1,3 @@
 module Subprocess
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end


### PR DESCRIPTION
While using `Subprocess.check_output` with the `cwd:` option, I encountered this exception:

```
17:28:58 /var/lib/gems/2.1.0/gems/subprocess-1.3.0/lib/subprocess.rb:253:in `block in initialize': uninitialized constant Subprocess::Process::FileUtils (NameError)
17:28:58 	from /var/lib/gems/2.1.0/gems/subprocess-1.3.0/lib/subprocess.rb:251:in `fork'
17:28:58 	from /var/lib/gems/2.1.0/gems/subprocess-1.3.0/lib/subprocess.rb:251:in `initialize'
17:28:58 	from /var/lib/gems/2.1.0/gems/subprocess-1.3.0/lib/subprocess.rb:85:in `new'
17:28:58 	from /var/lib/gems/2.1.0/gems/subprocess-1.3.0/lib/subprocess.rb:85:in `check_output'
17:28:58 	from /pay/jenkins/stripe/scripts/postprocess-coverage.rb:68:in `main'
17:28:58 	from /pay/jenkins/stripe/scripts/postprocess-coverage.rb:73:in `<main>'
```

Line 253 uses the `FileUtils` module, but unless this module has already been brought into the global namespace, this call will fail.

Incidentally, the unit test

https://github.com/stripe/subprocess/blob/master/test/test_subprocess.rb#L185

Succeeds because the test file requires `tempfile`, which transitively brings `fileutils` into the global namespace.