### PR TITLE
Handle non-ASCII output from commands

### DIFF
--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -362,6 +362,9 @@ module Subprocess
       raise ArgumentError if !input.nil? && @stdin.nil?
 
       stdout, stderr = "", ""
+      stdout_encoding = @stdout.external_encoding if @stdout
+      stderr_encoding = @stderr.external_encoding if @stderr
+
       input = input.dup unless input.nil?
 
       @stdin.close if (input.nil? || input.empty?) && !@stdin.nil?
@@ -422,6 +425,9 @@ module Subprocess
       end
 
       wait
+
+      stdout.force_encoding(stdout_encoding) if stdout_encoding
+      stderr.force_encoding(stderr_encoding) if stderr_encoding
 
       [stdout, stderr]
     end

--- a/lib/subprocess/version.rb
+++ b/lib/subprocess/version.rb
@@ -1,3 +1,3 @@
 module Subprocess
-  VERSION = '1.3.1'
+  VERSION = '1.3.2'
 end

--- a/test/test_subprocess.rb
+++ b/test/test_subprocess.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rubygems'
 gem 'minitest'
 require 'minitest/autorun'
@@ -266,6 +267,12 @@ describe Subprocess do
       children = pid_table.find_all{ |pid, ppid| ppid == $$ && pid != ps_pid }
 
       children.must_equal([])
+    end
+
+    it "properly encodes output strings" do
+      test_string = 'aå'
+      output = Subprocess.check_output(['echo', '-n', test_string])
+      output.must_equal(test_string)
     end
   end
 end


### PR DESCRIPTION
Subprocess always returns output strings encoded as ASCII-8BIT even if
the IO uses a different encoding. `read_nonblock` really can't do
anything else since it's reading raw bytes and might split up Unicode
characters. Instead, we need to set the encoding of the complete
string after we're done receiving it. `external_encoding` isn't
readable on closed IOs so we have to read that at the beginning of
`communicate`.