### PR TITLE
Don't treat WaitWritable on stdin as an error

### DIFF
--- a/lib/subprocess/version.rb
+++ b/lib/subprocess/version.rb
@@ -1,3 +1,3 @@
 module Subprocess
-  VERSION = '1.3.2'
+  VERSION = '1.3.3'
 end


### PR DESCRIPTION
We've had several reports of people running OS X getting an `EAGAINWaitWritable` error from Subprocess writing to stdin. Rebooting the machine seems to fix the issue. On a non-rebooted machine, I was able to verify that after writing 512 bytes to a new pipe, subsequent writes would throw an error even immediately after `select` indicated that the fd is writable:
```
>> data = "a" * 819;
>> r, w = IO.pipe;
>> IO.select([], [w])
[[], [#<IO:fd 11>], []]
>> w.write_nonblock(data)
512
>> IO.select([], [w])
[[], [#<IO:fd 11>], []]
>> w.write_nonblock(data)
<raises EAGAINWaitWritable>
>> IO.select([], [w])
[[], [#<IO:fd 11>], []]
```

I was also able to confirm that this diff fixes the observed issue and the Subprocess completes cleanly.

There's some precedent for making this change:
* As far as I can tell, OpenSSH swallows EAGAIN and continues looping: https://github.com/openssh/openssh-portable/blob/ca04de83f210959ad2ed870a30ba1732c3ae00e3/packet.c#L2178-L2180
* In another place, OpenSSH notes that Solaris has experienced a similar kernel bug: https://github.com/openssh/openssh-portable/blob/8d0578478586e283e751ca51e7b0690631da139a/clientloop.c#L780-L786
* The POSIX standard states that it's acceptable for a `write` to return an error even if `select` indicates writability:

> A descriptor shall be considered ready for reading when a call to an input function with O_NONBLOCK clear would not block, whether or not the function would transfer data successfully. (The function might return data, an end-of-file indication, or an error other than one indicating that it is blocked, and in each of these cases the descriptor shall be considered ready for reading.)
> 
> A descriptor shall be considered ready for writing when a call to an output function with O_NONBLOCK clear would not block, whether or not the function would transfer data successfully.
> 

If the OS misbehaves *and* the process blocks forever, the invoking process will spinloop indefinitely. I think this is acceptable since it's already good practice to implement a timeout if you don't trust the child process not to block indefinitely. 