### PR TITLE
Fix the exit condition for Subprocess

### DIFF
--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -376,16 +376,6 @@ module Subprocess
         loop do
           ready_r, ready_w = select(wait_r, wait_w)
 
-          # If the child exits, we still have to be sure to read any data left
-          # in the pipes. So we poll the child, drain all the pipes, and *then*
-          # check @status.
-          #
-          # It's very important that we do not call poll between draining the
-          # pipes and checking @status. If we did, we open a race condition
-          # where the child writes to stdout and exits in that brief window,
-          # causing us to lose that data.
-          poll
-
           if ready_r.include?(@stdout)
             if drain_fd(@stdout, stdout)
               wait_r.delete(@stdout)
@@ -424,10 +414,9 @@ module Subprocess
             end
           end
 
-          break if @status
-
-          # If there's nothing left to wait for, we're done!
-          break if wait_r.length == 0 && wait_w.length == 0
+          # If the process has exited and we're not waiting to read anything
+          # other than the self pipe, then we're done.
+          break if poll && (wait_r.length == 0 || wait_r == [self_read])
         end
       end
 

--- a/lib/subprocess/version.rb
+++ b/lib/subprocess/version.rb
@@ -1,3 +1,3 @@
 module Subprocess
-  VERSION = '1.3.3'
+  VERSION = '1.3.4'
 end


### PR DESCRIPTION
Subprocess a bug in which it can fail to read data buffered in pipes
after the process terminates. It currently attempts to handle this
case by calling `drain_fd` on each ready fd after detecting that the
process has exited by calling `poll`. If the process writes to the
pipe between the `select` and the `poll`, we won't attempt to read
from that pipe. This can happen if the process write to stderr, then
writes to stdout and then exits. `select` will return after the write
to stderr then the child writes to stdout and exits and then we poll.
I think there's also an edge case where the process receives an
interupt in `drain_fd` after the child has exited and catches EINTR.

Instead we should continue looping until we've received EOF or EPIPE from
each of the read pipes except the self_pipe. We can remove the termination condition
that waits for `wait_r.length == 0` since that will never be reached
since the self_pipe is never removed from wait_r and should never
be nil.