### PR TITLE
Fix a deadlock in #communicate

### DIFF
--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -374,6 +374,10 @@ module Subprocess
         wait_r = [@stdout, @stderr, self_read].compact
         wait_w = [input && @stdin].compact
         loop do
+          # If the process has exited and we're not waiting to read anything
+          # other than the self pipe, then we're done.
+          break if poll && wait_r == [self_read]
+
           ready_r, ready_w = select(wait_r, wait_w)
 
           if ready_r.include?(@stdout)
@@ -420,10 +424,6 @@ module Subprocess
               wait_w.delete(@stdin)
             end
           end
-
-          # If the process has exited and we're not waiting to read anything
-          # other than the self pipe, then we're done.
-          break if poll && wait_r == [self_read]
         end
       end
 

--- a/test/test_subprocess.rb
+++ b/test/test_subprocess.rb
@@ -4,6 +4,7 @@ gem 'minitest'
 require 'minitest/autorun'
 require 'subprocess'
 
+require 'timeout'
 require 'pathname'
 require 'tempfile'
 
@@ -230,6 +231,14 @@ describe Subprocess do
         string = "x" * 1024 * 1024 * 16
         stdout, stderr = p.communicate(string)
         stdout.must_equal(string)
+      end
+    end
+
+    it 'does not deadlock if you #communicate without any pipes' do
+      Timeout.timeout(5) do
+        p = Subprocess.popen(['true'])
+        p.wait
+        out, err = p.communicate
       end
     end
 


### PR DESCRIPTION
If you call #communicate on a process with no open pipes, and the
process exits before we enter the `catching_sigchld` block, we would
deadlock forever waiting on a SIGCHLD that would never arrive.

Arguably calling `#communicate` on a process with no open pipes should
be an error, but it's arguably useful as a synonym for `#wait` if you
don't know whether or not there's output, and I'm wary of breaking
clients.

r? @evan-stripe 
cc @andrew-stripe