### PR TITLE
Provide helpful messages for invalid cmd and env arguments

### DIFF
--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -224,7 +224,7 @@ module Subprocess
     #   in conjunction with {Subprocess::check_call}.
     # @yieldparam process [Process] The process that was just spawned.
     def initialize(cmd, opts={}, &blk)
-      raise ArgumentError, "cmd must be an Array" unless Array === cmd
+      raise ArgumentError, "cmd must be an Array of strings" unless Array === cmd
       raise ArgumentError, "cmd cannot be empty" if cmd.empty?
 
       @command = cmd
@@ -257,7 +257,11 @@ module Subprocess
           # Set up a new environment if we're requested to do so.
           if opts[:env]
             ENV.clear
-            ENV.update(opts[:env])
+            begin
+              ENV.update(opts[:env])
+            rescue TypeError => e
+              raise ArgumentError, "`env` option must be a hash where all keys and values are strings (#{e})"
+            end
           end
 
           # Call the user back, maybe?
@@ -268,13 +272,17 @@ module Subprocess
             retained_fds.each { |fd| options[fd] = fd }
           end
 
-          # Ruby's Kernel#exec will call an exec(3) variant if called with two
-          # or more arguments, but when called with just a single argument will
-          # spawn a subshell with that argument as the command. Since we always
-          # want to call exec(3), we use the third exec form, which passes a
-          # [cmdname, argv0] array as its first argument and never invokes a
-          # subshell.
-          exec([cmd[0], cmd[0]], *cmd[1..-1], options)
+          begin
+            # Ruby's Kernel#exec will call an exec(3) variant if called with two
+            # or more arguments, but when called with just a single argument will
+            # spawn a subshell with that argument as the command. Since we always
+            # want to call exec(3), we use the third exec form, which passes a
+            # [cmdname, argv0] array as its first argument and never invokes a
+            # subshell.
+            exec([cmd[0], cmd[0]], *cmd[1..-1], options)
+          rescue TypeError => e
+            raise ArgumentError, "cmd must be an Array of strings (#{e})"
+          end
 
         rescue Exception => e
           # Dump all errors up to the parent through the control socket

--- a/test/test_subprocess.rb
+++ b/test/test_subprocess.rb
@@ -27,6 +27,16 @@ describe Subprocess do
         Subprocess.popen("not an Array")
       }.must_raise(ArgumentError)
     end
+
+    it 'complains with a helpful error when given arrays with invalid elements' do
+      exp = lambda {
+        Subprocess.popen(["not", [:allowed], 5])
+      }.must_raise(ArgumentError)
+      assert_equal(
+        "cmd must be an Array of strings (no implicit conversion of Array into String)",
+        exp.message
+      )
+    end
   end
 
   describe '.call' do
@@ -195,6 +205,17 @@ describe Subprocess do
       env = {"weather" => "warm and sunny"}
       out = Subprocess.check_output(['sh', '-c', 'echo $weather'], :env => env)
       out.chomp.must_equal(env['weather'])
+    end
+
+    it 'provides helpful error messages with invalid environment arguments' do
+      env = {symbol_key: "value"}
+      exp = lambda {
+        Subprocess.call(['false'], :env => env)
+      }.must_raise(ArgumentError)
+      assert_equal(
+        "`env` option must be a hash where all keys and values are strings (no implicit conversion of Symbol into String)",
+        exp.message
+      )
     end
 
     it 'retains files when asked' do


### PR DESCRIPTION
Currently when you supply an invalid cmd or env you get a generic TypeError from inside some Ruby C code that gives you no indication of what you did wrong. This wraps those exceptions in a message that at least tells you what argument you messed up.

r? @nelhage 