### PR TITLE
Handle EPIPE in handle_sigchld.

### DIFF
--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -505,7 +505,7 @@ module Subprocess
       @sigchld_fds.values.each do |fd|
         begin
           fd.write_nonblock("\x00")
-        rescue Errno::EWOULDBLOCK, Errno::EAGAIN
+        rescue Errno::EWOULDBLOCK, Errno::EAGAIN, Errno::EPIPE
         end
       end
     end

--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -506,6 +506,17 @@ module Subprocess
         begin
           fd.write_nonblock("\x00")
         rescue Errno::EWOULDBLOCK, Errno::EAGAIN, Errno::EPIPE
+          # If the pipe is full, the other end will be woken up
+          # regardless when it next reads, so it's fine to skip the
+          # write (the pipe is a wakeup channel, and doesn't contain
+          # meaningful data).
+          #
+          # We've seen EPIPE happen in production and don't fully
+          # understand it as of this writing, but if the other end has
+          # gone away, then there's no need to notify it and we'll
+          # just eat the error and move on. Plausibly we should remove
+          # the fd from `@sigchld_fds`, but since we don't have the
+          # lock I'm wary of trying to edit it.
         end
       end
     end


### PR DESCRIPTION
It's not at present entirely clear how this can happen; My best theory
involves forking-with-active-threads, which is unsafe in other
ways. However, this patch seems ~clearly correct; If the reader has
gone away for whatever reason, it should be safe to drop the wakeup.

r? @andrew-stripe 