### PR TITLE
Use block form of Dir.chdir

### DIFF
--- a/lib/subprocess/version.rb
+++ b/lib/subprocess/version.rb
@@ -1,3 +1,3 @@
 module Subprocess
-  VERSION = '1.3.6'
+  VERSION = '1.3.7'
 end


### PR DESCRIPTION
This switches from calling FileUtils.cd (an alias for Dir.chdir) to using the block form of Dir.chdir. Unless you use the block form, invoking Subprocess with the cwd option within another chdir block triggers a warning message on the console from:
https://github.com/ruby/ruby/blob/v2_4_1/dir.c#L1033-L1034

I recommend reviewing with `?w=1` since this is almost all whitespace change.

r? @nelhage 
cc @stripe/product-infra 