### PR TITLE
Fix Errno::EMFILE with cwd caused by #29

### DIFF
--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -1,3 +1,4 @@
+require 'fileutils'
 require 'thread'
 require 'set'
 
@@ -243,45 +244,46 @@ module Subprocess
 
       @pid = fork do
         begin
-          with_optional_cwd(opts[:cwd]) do
-            ::STDIN.reopen(@child_stdin) if @child_stdin
-            ::STDOUT.reopen(@child_stdout) if @child_stdout
-            if opts[:stderr] == STDOUT
-              ::STDERR.reopen(::STDOUT)
-            else
-              ::STDERR.reopen(@child_stderr) if @child_stderr
-            end
+          FileUtils.cd(opts[:cwd]) if opts[:cwd]
 
-            # Set up a new environment if we're requested to do so.
-            if opts[:env]
-              ENV.clear
-              begin
-                ENV.update(opts[:env])
-              rescue TypeError => e
-                raise ArgumentError, "`env` option must be a hash where all keys and values are strings (#{e})"
-              end
-            end
+          ::STDIN.reopen(@child_stdin) if @child_stdin
+          ::STDOUT.reopen(@child_stdout) if @child_stdout
+          if opts[:stderr] == STDOUT
+            ::STDERR.reopen(::STDOUT)
+          else
+            ::STDERR.reopen(@child_stderr) if @child_stderr
+          end
 
-            # Call the user back, maybe?
-            opts[:preexec_fn].call if opts[:preexec_fn]
-
-            options = {close_others: true}.merge(opts.fetch(:exec_opts, {}))
-            if opts[:retain_fds]
-              retained_fds.each { |fd| options[fd] = fd }
-            end
-
+          # Set up a new environment if we're requested to do so.
+          if opts[:env]
+            ENV.clear
             begin
-              # Ruby's Kernel#exec will call an exec(3) variant if called with two
-              # or more arguments, but when called with just a single argument will
-              # spawn a subshell with that argument as the command. Since we always
-              # want to call exec(3), we use the third exec form, which passes a
-              # [cmdname, argv0] array as its first argument and never invokes a
-              # subshell.
-              exec([cmd[0], cmd[0]], *cmd[1..-1], options)
+              ENV.update(opts[:env])
             rescue TypeError => e
-              raise ArgumentError, "cmd must be an Array of strings (#{e})"
+              raise ArgumentError, "`env` option must be a hash where all keys and values are strings (#{e})"
             end
           end
+
+          # Call the user back, maybe?
+          opts[:preexec_fn].call if opts[:preexec_fn]
+
+          options = {close_others: true}.merge(opts.fetch(:exec_opts, {}))
+          if opts[:retain_fds]
+            retained_fds.each { |fd| options[fd] = fd }
+          end
+
+          begin
+            # Ruby's Kernel#exec will call an exec(3) variant if called with two
+            # or more arguments, but when called with just a single argument will
+            # spawn a subshell with that argument as the command. Since we always
+            # want to call exec(3), we use the third exec form, which passes a
+            # [cmdname, argv0] array as its first argument and never invokes a
+            # subshell.
+            exec([cmd[0], cmd[0]], *cmd[1..-1], options)
+          rescue TypeError => e
+            raise ArgumentError, "cmd must be an Array of strings (#{e})"
+          end
+
         rescue Exception => e
           # Dump all errors up to the parent through the control socket
           Marshal.dump(e, control_w)
@@ -542,14 +544,6 @@ module Subprocess
       yield
     ensure
       unregister_pid(pid)
-    end
-
-    def with_optional_cwd(cwd, &block)
-      if cwd
-        Dir.chdir(cwd, &block)
-      else
-        yield
-      end
     end
   end
 end

--- a/lib/subprocess/version.rb
+++ b/lib/subprocess/version.rb
@@ -1,3 +1,3 @@
 module Subprocess
-  VERSION = '1.3.6'
+  VERSION = '1.3.8'
 end

--- a/lib/subprocess/version.rb
+++ b/lib/subprocess/version.rb
@@ -1,3 +1,3 @@
 module Subprocess
-  VERSION = '1.3.7'
+  VERSION = '1.3.6'
 end


### PR DESCRIPTION
Note to reviewers: The first commit here is a straight revert of #29. I'd suggest reviewing only the second commit (note that commit bumps the version two numbers because the revert rolled it back).

Using `FileUtils.cd` (an alias for `Dir.chdir`) triggers a warning message when Subprocess is called with the cwd arg from inside another chdir block:
https://github.com/ruby/ruby/blob/v2_4_1/dir.c#L1033-L1034

In #29, I tried fixing this by using the block form of `Dir.chdir` but that caused many people to see errors of the form:
```
<elided>/subprocess-1.3.7/lib/subprocess.rb:280:in `exec': Too many open files - getcwd (Errno::EMFILE)
```

Instead of calling `chdir` in Ruby, I think it makes more sense to pass `chdir` as an argument to exec.

I still have to call `Dir.chdir` around a `preexec_fn` so that it continues to operate in the new working directory. We don't depend on that behavior anywhere at Stripe but it's possible someone else does. I suspect the bug was some interaction between `Dir.chdir` and `exec` so this feels safe.

cc @stripe/product-infra 
r? @nelhage 