### PR TITLE
Add a timeout parameter to `communicate`

### DIFF
--- a/lib/subprocess/version.rb
+++ b/lib/subprocess/version.rb
@@ -1,3 +1,3 @@
 module Subprocess
-  VERSION = '1.3.8'
+  VERSION = '1.4.0'
 end


### PR DESCRIPTION
This adds an optional `timeout_s` parameter to communicate that causes it to time out after some number of seconds. This is useful in handling processes that can hang under certain conditions. For example, you might want to timeout after a certain time and then call `terminate` to kill the process.

r? @russell-stripe 
cc @stripe/product-infra @zenazn 