### PR TITLE
Wakeup SIGCHLD listeners on a separate thread.

### DIFF
--- a/lib/subprocess/version.rb
+++ b/lib/subprocess/version.rb
@@ -1,3 +1,3 @@
 module Subprocess
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 end


### PR DESCRIPTION
This enables us to properly grab the `@sigchld_mutex` and synchronize
with writers.

It turns out that signal handlers execute on the main thread and may
interleave with other writers. This manifested as `handle_sigchld`
`write`ing to pipes that had already been closed (by the `IO.pipe`)
block, resulting in nasty exceptions.

By grabbing the lock, we ensure that we serialize reading the list of
wakeup pipes properly with respect to writers.

r? @andrew-stripe 