### PR TITLE
Add support for partial reads from Subprocess#communicate

### DIFF
--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -422,19 +422,16 @@ module Subprocess
           ready_r, ready_w = select_until(wait_r, wait_w, [], timeout_at)
           raise CommunicateTimeout.new(@command, stdout, stderr) if ready_r.nil?
 
-          read_output = false
           if ready_r.include?(@stdout)
             if drain_fd(@stdout, stdout)
               wait_r.delete(@stdout)
             end
-            read_output = true
           end
 
           if ready_r.include?(@stderr)
             if drain_fd(@stderr, stderr)
               wait_r.delete(@stderr)
             end
-            read_output = true
           end
 
           if ready_r.include?(self_read)
@@ -470,7 +467,7 @@ module Subprocess
             end
           end
 
-          if read_output && block_given?
+          if block_given? && !(stderr.empty? && stdout.empty?)
             yield stdout, stderr
             stdout, stderr = "", ""
           end

--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -30,7 +30,7 @@ module Subprocess
   #
   # @return [::Process::Status] The exit status of the process
   #
-  # @see {Process#initialize}
+  # @see Process#initialize
   def self.call(cmd, opts={}, &blk)
     Process.new(cmd, opts, &blk).wait
   end
@@ -62,7 +62,7 @@ module Subprocess
   #   was terminated with an error or was killed by a signal)
   # @return [::Process::Status] The exit status of the process
   #
-  # @see {Process#initialize}
+  # @see Process#initialize
   def self.check_call(cmd, opts={}, &blk)
     status = Process.new(cmd, opts, &blk).wait
     raise NonZeroExit.new(cmd, status) unless status.success?
@@ -79,7 +79,7 @@ module Subprocess
   #   was terminated with an error or was killed by a signal)
   # @return [String] The contents of `stdout`
   #
-  # @see {Process#initialize}
+  # @see Process#initialize
   def self.check_output(cmd, opts={}, &blk)
     opts[:stdout] = PIPE
     child = Process.new(cmd, opts, &blk)
@@ -381,9 +381,11 @@ module Subprocess
       false
     end
 
-    # Write the (optional) input to the process's `stdin`. Also, read (and
-    # buffer in memory) the contents of `stdout` and `stderr`. Do this all using
-    # `IO::select`, so we don't deadlock due to full pipe buffers.
+    # Write the (optional) input to the process's `stdin` and read the contents of
+    # `stdout` and `stderr`. If a block is provided, stdout and stderr are yielded as they
+    # are read. Otherwise they are buffered in memory and returned when the process
+    # exits. Do this all using `IO::select`, so we don't deadlock due to full pipe
+    # buffers.
     #
     # This is only really useful if you set some of `:stdin`, `:stdout`, and
     # `:stderr` to {Subprocess::PIPE}.
@@ -391,10 +393,9 @@ module Subprocess
     # @param [String] input A string to feed to the child's standard input.
     # @param [Numeric] timeout_s Raise {Subprocess::CommunicateTimeout} if communicate
     #   does not finish after timeout_s seconds.
-    # @yield [Array<String>] Called whenever data is read from stdout or stderr.
-    #   Arguments are an array of two elements: the data read from the
-    #   child's standard output and standard error since the last call, respectively.
-    # @return [Array<String>, nil] An array of two elements: the data read from the
+    # @yieldparam [String] stdout Data read from stdout since the last yield
+    # @yieldparam [String] stderr Data read from stderr since the last yield
+    # @return [Array(String, String), nil] An array of two elements: the data read from the
     #   child's standard output and standard error, respectively.
     #   Returns nil if a block is provided.
     def communicate(input=nil, timeout_s=nil)

--- a/lib/subprocess/version.rb
+++ b/lib/subprocess/version.rb
@@ -1,3 +1,3 @@
 module Subprocess
-  VERSION = '1.4.2'
+  VERSION = '1.5.0'
 end

--- a/test/test_subprocess.rb
+++ b/test/test_subprocess.rb
@@ -347,11 +347,6 @@ EOF
           when 1
             stderr.must_equal("")
             stdout.must_equal("bar\n")
-          when 2, 3
-            # It's possible to loop one more time for each pipe depending on when exactly
-            # the process exits.
-            stderr.must_equal("")
-            stdout.must_equal("")
           else
             raise "Unexpected #{called+1}th call to `communicate` with `#{stdout}` and `#{stderr}`"
           end


### PR DESCRIPTION
It can be useful to read partial output from a long running process before it completes (e.g. to provide feedback to the user about the progress). This adds the ability to pass a block to `communicate` that gets called with data read from stdout/stderr as its read instead of returning it.

r? @nelhage 