### PR TITLE
Don't spawn a thread from inside the signal handler.

### DIFF
--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -412,12 +412,13 @@ module Subprocess
       timeout_at = Time.now + timeout_s if timeout_s
 
       self.class.catching_sigchld(pid) do |self_read|
-        wait_r = [@stdout, @stderr, self_read].compact
+        global_read = self.class.sigchld_global_read
+        wait_r = [@stdout, @stderr, self_read, global_read].compact
         wait_w = [input && @stdin].compact
         loop do
           # If the process has exited and we're not waiting to read anything
           # other than the self pipe, then we're done.
-          break if poll && wait_r == [self_read]
+          break if poll && wait_r == [self_read, global_read]
 
           ready_r, ready_w = select_until(wait_r, wait_w, [], timeout_at)
           raise CommunicateTimeout.new(@command, stdout, stderr) if ready_r.nil?
@@ -432,6 +433,11 @@ module Subprocess
             if drain_fd(@stderr, stderr)
               wait_r.delete(@stderr)
             end
+          end
+
+          if ready_r.include?(global_read)
+            drain_fd(global_read)
+            self.class.wakeup_sigchld
           end
 
           if ready_r.include?(self_read)
@@ -551,27 +557,45 @@ module Subprocess
     @sigchld_mutex = Mutex.new
     @sigchld_fds = {}
     @sigchld_old_handler = nil
+    @sigchld_global_write = nil
+    @sigchld_global_read = nil
+
+    def self.sigchld_global_read
+      @sigchld_global_read
+    end
+
+    def self.handle_sigchld
+      # We'd like to just notify everything in `@sigchld_fds`, but
+      # ruby signal handlers are not executed atomically with respect
+      # to other Ruby threads, so reading it is racy. We can't grab
+      # `@sigchld_mutex`, because signal execution blocks the main
+      # thread, and so we'd deadlock if the main thread currently
+      # holds it.
+      #
+      # Instead, we keep a long-lived notify self-pipe that we select
+      # on inside `communicate`, and we task `communicate` with
+      # grabbing the lock and fanning out the wakeups.
+      begin
+        @sigchld_global_write.write_nonblock("\x00")
+      rescue Errno::EWOULDBLOCK, Errno::EAGAIN
+        nil # ignore
+      end
+    end
 
     # Wake up everyone. We can't tell who we should wake up without `wait`ing,
     # and we want to let the process itself do that. In practice, we're not
     # likely to have that many in-flight subprocesses, so this is probably not a
     # big deal.
-    def self.handle_sigchld
-      # Do the wakeups inside a thread so that we can safely grab
-      # `sigchld_mutex`. Ruby signal handlers are not executed
-      # atomically with respect to other Ruby threads, so we need to
-      # properly synchronize.
-      Thread.new do
-        @sigchld_mutex.synchronize do
-          @sigchld_fds.values.each do |fd|
-            begin
-              fd.write_nonblock("\x00")
-            rescue Errno::EWOULDBLOCK, Errno::EAGAIN
-              # If the pipe is full, the other end will be woken up
-              # regardless when it next reads, so it's fine to skip the
-              # write (the pipe is a wakeup channel, and doesn't contain
-              # meaningful data).
-            end
+    def self.wakeup_sigchld
+      @sigchld_mutex.synchronize do
+        @sigchld_fds.values.each do |fd|
+          begin
+            fd.write_nonblock("\x00")
+          rescue Errno::EWOULDBLOCK, Errno::EAGAIN
+            # If the pipe is full, the other end will be woken up
+            # regardless when it next reads, so it's fine to skip the
+            # write (the pipe is a wakeup channel, and doesn't contain
+            # meaningful data).
           end
         end
       end
@@ -581,6 +605,9 @@ module Subprocess
       @sigchld_mutex.synchronize do
         @sigchld_fds[pid] = fd
         if @sigchld_fds.length == 1
+          if @sigchld_global_write.nil?
+            @sigchld_global_read, @sigchld_global_write = IO.pipe
+          end
           @sigchld_old_handler = Signal.trap('SIGCHLD') {handle_sigchld}
         end
       end

--- a/lib/subprocess/version.rb
+++ b/lib/subprocess/version.rb
@@ -1,3 +1,3 @@
 module Subprocess
-  VERSION = '1.5.0'
+  VERSION = '1.5.1'
 end


### PR DESCRIPTION
This extra thread is causing issues with our CI infrastructure, which
makes assertions that tests don't leak threads.

Instead, create a single self-pipe that the signal handler writes
into; All `communicate` loops read from that pipe and then grab the
mutex and rebroadcast the wakeup. Since they're running in normal
threads, they can safely synchronize.

r? @andrew-stripe 