### PR TITLE
Make the global self-read pipe `fork`-safe

### DIFF
--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -604,6 +604,10 @@ module Subprocess
         @sigchld_fds[pid] = fd
         if @sigchld_fds.length == 1
           if @sigchld_global_write.nil? || @sigchld_pipe_pid != ::Process.pid
+            # Check the PID so that if we fork we will re-open the
+            # pipe. It's important that a fork parent and child don't
+            # share this pipe, because if they do they risk stealing
+            # each others' wakeups.
             @sigchld_pipe_pid = ::Process.pid
             @sigchld_global_read, @sigchld_global_write = IO.pipe
           end

--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -560,6 +560,7 @@ module Subprocess
     @sigchld_old_handler = nil
     @sigchld_global_write = nil
     @sigchld_global_read = nil
+    @sigchld_pipe_pid = nil
 
     def self.handle_sigchld
       # We'd like to just notify everything in `@sigchld_fds`, but
@@ -602,7 +603,8 @@ module Subprocess
       @sigchld_mutex.synchronize do
         @sigchld_fds[pid] = fd
         if @sigchld_fds.length == 1
-          if @sigchld_global_write.nil?
+          if @sigchld_global_write.nil? || @sigchld_pipe_pid != ::Process.pid
+            @sigchld_pipe_pid = ::Process.pid
             @sigchld_global_read, @sigchld_global_write = IO.pipe
           end
           @sigchld_old_handler = Signal.trap('SIGCHLD') {handle_sigchld}

--- a/lib/subprocess/version.rb
+++ b/lib/subprocess/version.rb
@@ -1,3 +1,3 @@
 module Subprocess
-  VERSION = '1.5.1'
+  VERSION = '1.5.2'
 end


### PR DESCRIPTION
If we `fork`, it's important that the child and parent don't share a self-read pipe, since if they do, they risk stealing each others' events.

Check the PID and re-create the pipe if it's changed. This is theoretically subject to PID-wraparound issues, but should work well enough.

r? @andrew-stripe 