### PR TITLE
Do not hang in communicate if spawned process forks

### DIFF
--- a/lib/subprocess/version.rb
+++ b/lib/subprocess/version.rb
@@ -1,3 +1,3 @@
 module Subprocess
-  VERSION = '1.5.2'
+  VERSION = '1.5.3'
 end

--- a/test/test_subprocess.rb
+++ b/test/test_subprocess.rb
@@ -294,6 +294,16 @@ EOF
       end
     end
 
+    it 'does not deadlock when communicating with a process that forks' do
+      script = <<EOF
+  echo "fork"
+  (echo "me" && sleep 10) &
+EOF
+      p = Subprocess::Process.new(['bash', '-c', script], stdout: Subprocess::PIPE)
+      stdout, _stderr = p.communicate(nil, 5)
+      stdout.must_include("fork\n")
+    end
+
     it 'should not raise an error when the process closes stdin before we finish writing' do
       script = File.join(File.dirname(__FILE__), 'bin', 'closer.rb')
       Subprocess.check_call(['bash', '-c', '<&-; echo -n "foo"; sleep 1'], :stdin => Subprocess::PIPE,


### PR DESCRIPTION
Currently we only exit the `communicate` loop when we get an EOF from stdout and stderr. If the child process forks before exiting, the fork will inherit those file descriptors and `communicate` will hang until the child exits. I believe it's preferable to drain stdout/stderr after the process exits and then break out of the `communicate` loop.

Note that Open3 similarly hangs waiting for EOF. There is a risk that existing software depends on this behavior and that output could be non-deterministic if the forked grandchild is writing to stdout/stderr. Do you think that's acceptable?

r? @nelhage-stripe 