### PR TITLE
Yield status to `communicate` block on exit

### DIFF
--- a/lib/subprocess/version.rb
+++ b/lib/subprocess/version.rb
@@ -1,3 +1,3 @@
 module Subprocess
-  VERSION = '1.5.2'
+  VERSION = '1.5.3'
 end

--- a/test/test_subprocess.rb
+++ b/test/test_subprocess.rb
@@ -347,6 +347,9 @@ EOF
           when 1
             stderr.must_equal("")
             stdout.must_equal("bar\n")
+          when 2, 3, 4 # May loop separately for self_read, stdout and stderr
+            stderr.must_equal("")
+            stdout.must_equal("")
           else
             raise "Unexpected #{called+1}th call to `communicate` with `#{stdout}` and `#{stderr}`"
           end
@@ -355,6 +358,33 @@ EOF
         end
 
         res.must_be_nil
+      end
+    end
+
+    it 'yields on exit even when a forked process holds open stdout/stderr' do
+      IO.pipe do |r, w|
+        called = 0
+        script = "(cat <&#{r.fileno}) &\nexit 22"
+
+        p = Subprocess::Process.new(
+          ['bash', '-c', script],
+          stdout: Subprocess::PIPE,
+          retain_fds: [r.fileno]
+        )
+        p.communicate(nil, 5) do |stdout, _stderr, status|
+          case called
+          when 0
+            stdout.must_equal("")
+            status.exitstatus.must_equal(22)
+            w.write("foo")
+            w.close
+          when 1
+            stdout.must_equal("foo")
+          else
+            raise "Unexpected #{called+1} call to `communicate`"
+          end
+          called += 1
+        end
       end
     end
 


### PR DESCRIPTION
Currently we only exit the `communicate` loop when we get an EOF from stdout and stderr. If the child process forks before exiting, the fork will inherit those file descriptors and `communicate` will hang until the child exits. By yielding the status to a block passed to `communicate` after reading from `self_read`, we allow the caller to break out of `communicate` instead of hanging. This is an alternative to #39.

r? @nelhage-stripe 