### PR TITLE
Apply captured encoding settings on output from partial reads in Process#communicate

### DIFF
--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -478,6 +478,9 @@ module Subprocess
             end
           end
 
+          stdout.force_encoding(stdout_encoding) if stdout_encoding
+          stderr.force_encoding(stderr_encoding) if stderr_encoding
+
           if block_given? && !(stderr.empty? && stdout.empty?)
             yield stdout, stderr
             stdout, stderr = "", ""
@@ -486,9 +489,6 @@ module Subprocess
       end
 
       wait
-
-      stdout.force_encoding(stdout_encoding) if stdout_encoding
-      stderr.force_encoding(stderr_encoding) if stderr_encoding
 
       if block_given?
         nil

--- a/test/test_subprocess.rb
+++ b/test/test_subprocess.rb
@@ -18,10 +18,10 @@ describe Subprocess do
 
   def call_multiwrite_script(&block)
     script = <<EOF
-sleep 10 &
-trap "echo bar; kill $!; exit" HUP
-echo foo 1>&2
-wait
+  sleep 10 &
+  trap "echo 你好; kill $!; exit" HUP
+  echo 世界 1>&2
+  wait
 EOF
 
     Subprocess.check_call(
@@ -350,13 +350,13 @@ EOF
         e = lambda {
           p.communicate(nil, 0.2)
         }.must_raise(Subprocess::CommunicateTimeout)
-        e.stderr.must_equal("foo\n")
+        e.stderr.must_equal("世界\n")
         e.stdout.must_equal("")
 
         # Send a signal and read the next echo
         p.send_signal('HUP')
         stdout, stderr = p.communicate
-        stdout.must_equal("bar\n")
+        stdout.must_equal("你好\n")
         stderr.must_equal("")
       end
     end
@@ -368,12 +368,12 @@ EOF
         res = p.communicate(nil, 5) do |stdout, stderr|
           case called
           when 0
-            stderr.must_equal("foo\n")
+            stderr.must_equal("世界\n")
             stdout.must_equal("")
             p.send_signal("HUP")
           when 1
             stderr.must_equal("")
-            stdout.must_equal("bar\n")
+            stdout.must_equal("你好\n")
           else
             raise "Unexpected #{called+1}th call to `communicate` with `#{stdout}` and `#{stderr}`"
           end


### PR DESCRIPTION
### Purpose
Handle encoding of output from `Process#communicate` identically whether a block is provided or not.

### Context
`Process#communicate` depends on Ruby's `IO#read_nonblock` via `Process#drain_fd`. Strings returned from `read_nonblock` are handled as `ASCII-8BIT` to prevent data loss. (For a demonstration of this behavior, download and run [this snippet](https://gist.github.com/andrew-breunig/69a1a6ffc5a1dbefa8d08dcd643bc912).) If output from a subprocess has a different encoding, this can lead to decoding errors.

When not provided a block, `Process#communicate` handles this by [capturing encoding settings](https://github.com/stripe/subprocess/blob/master/lib/subprocess.rb#L405-L406) at the beginning of the method and [re-applying these settings](https://github.com/stripe/subprocess/blob/master/lib/subprocess.rb#L490-L491) at the end of the method. However, when provided a block this method [yields output before re-applying these settings](https://github.com/stripe/subprocess/blob/master/lib/subprocess.rb#L482), so the output still retains the `ASCII-8BIT` settings applied by `read_nonblock`.

This results in an unexpected (at least for me) discrepancy between the encoding settings of output from `Process#communicate`, depending on the form of the method invoked. Any consumer that depends on output from partially completed commands must provide a block (see PR #36), and so becomes subject to potential decoding errors.

### Design
This branch resolves the issue by re-applying captured encoding settings before yielding output to the provided block.

One consideration: as written here, encoding settings will be re-applied every time the method attempts to read output. As noted in [this comment on PR #36](https://github.com/stripe/subprocess/pull/36#issuecomment-341188687), this step can be omitted when no output is present on `STDOUT` or `STDERR`. Since performing this step on an empty string is a no-op, and the previous implementation does not perform this check before re-applying encoding settings, the proposed changes favor readability.

### Testing
This branch modifies the "multiwrite script" in the test file to include non-ASCII characters, and updates dependent assertions. This modification reveals the potential for decoding errors when providing a block to `Process#communicate`.

Note that the modified tests fail without the included changes, but pass with the included changes.

"你好 世界" is [Google's translation](https://www.google.com/search?q=Hello+World+in+Chinese) of "Hello World" into Chinese.