### PR TITLE
subprocess: handle binary/unicode input to stdin

### DIFF
--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -430,7 +430,10 @@ module Subprocess
 
       stdout, stderr = "", ""
 
-      input = input.dup unless input.nil?
+      # NB: Always force encoding to binary so we handle unicode or binary input
+      # correctly across multiple write_nonblock calls, since we manually slice
+      # the input depending on how many bytes were written
+      input = input.dup.force_encoding('BINARY') unless input.nil?
 
       @stdin.close if (input.nil? || input.empty?) && !@stdin.nil?
 

--- a/test/test_subprocess.rb
+++ b/test/test_subprocess.rb
@@ -444,6 +444,19 @@ EOF
 
         assert_equal("你好世界", stdout)
       end
+
+      it 'handles binary data as stdin' do
+        message = 'ḧëḷḷöẅöṛḷḋ' * 64 * 1024
+        assert_equal(Encoding::UTF_8, message.encoding)
+
+        process = Subprocess::Process.new(['cat'], :stdin => Subprocess::PIPE, :stdout => Subprocess::PIPE)
+        stdout = ""
+        process.communicate(message) do |out, _err|
+          stdout << out
+        end
+        assert_equal(message.size, stdout.size)
+        assert_equal(message, stdout)
+      end
     end
   end
 end


### PR DESCRIPTION
# Summary
`Subprocess#communicate` does not handle Unicode data correctly when the input intended for the child's stdin is more than the `write_nonblock` limit (pipe size). Unicode input may have multi-byte characters, which don't play well with how Subprocess currently keeps track of which data still need to be written to child's stdin:

https://github.com/stripe/subprocess/blob/master/lib/subprocess.rb#L499

In particular `Encoding::UTF_8` strings will see dropped or corrupted data beyond the first pipe size boundary.

# Change details
This change calls `force_encoding` on all input passed to stdin so that assumptions baked into the byte slicing logic still hold.

# Testing
I've added a unit test that reproduces the issue and verified that the change fixes it.