### PR TITLE
Make Process#communicate do less work on every iteration

### DIFF
--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -499,7 +499,7 @@ module Subprocess
               @stdin.close
               wait_w.delete(@stdin)
             end
-            input[0...written] = ''
+            input = input[written..]
             if input.empty?
               @stdin.close
               wait_w.delete(@stdin)


### PR DESCRIPTION
Authored-by @synfo-stripe

> Without this change communicating 700MB worth of data to 'cat' takes
> ~1h, with it it's closer to 1s.
>
> My hypothesis is that `input[0...written] = ''` causes ruby to either
> allocate a whole new string buffer, or at the very least rewrite the
> entirety of the existing buffer, whereas `input = input[written..]` lets
> ruby use shared string optimization and only create a new RString
> pointing to the same buffer.