### PR TITLE
Test more Ruby versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.5, 2.6, 2.7]
+        ruby: [2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
@sydverisk's issue #73 nudged to me add more recent Ruby versions to our CI checks.

Test plan: we don't currently run CI for pull requests (we should probably fix that), but I was able to validate that CI passes on my own branch [here](https://github.com/qaisjp/subprocess/commits/b0e3499b7e85022e1c34b18552faf404293001e2/).