### PR TITLE
Convert the gem to frozen string literals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'bundler/gem_tasks'
 require 'bundler/setup'
 require 'rake/testtask'

--- a/lib/subprocess.rb
+++ b/lib/subprocess.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'thread'
 require 'set'
 
@@ -169,7 +170,7 @@ module Subprocess
     # @param [::Process::Status] status The status returned by `waitpid`.
     def initialize(cmd, status)
       @command, @status = cmd.join(' '), status
-      message = "Command #{command} "
+      message = +"Command #{command} "
       if status.exited?
         message << "returned non-zero exit status #{status.exitstatus}"
       elsif status.signaled?
@@ -428,7 +429,7 @@ module Subprocess
     def communicate(input=nil, timeout_s=nil)
       raise ArgumentError if !input.nil? && @stdin.nil?
 
-      stdout, stderr = "", ""
+      stdout, stderr = +"", +""
 
       # NB: Always force encoding to binary so we handle unicode or binary input
       # correctly across multiple write_nonblock calls, since we manually slice
@@ -508,7 +509,7 @@ module Subprocess
 
           if block_given? && !(stderr.empty? && stdout.empty?)
             yield stdout, stderr
-            stdout, stderr = "", ""
+            stdout, stderr = +"", +""
           end
         end
       end

--- a/lib/subprocess/version.rb
+++ b/lib/subprocess/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Subprocess
   VERSION = '1.5.6'
 end

--- a/subprocess.gemspec
+++ b/subprocess.gemspec
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'subprocess/version'

--- a/test/test_subprocess.rb
+++ b/test/test_subprocess.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 require 'rubygems'
 gem 'minitest'
 require 'minitest/autorun'
@@ -436,7 +437,7 @@ EOF
 
       it 'preserves encoding  across IO selection cycles with a block given' do
         process = Subprocess::Process.new(['bash', '-c', script], :stdout => Subprocess::PIPE)
-        stdout = ""
+        stdout = +""
 
         process.communicate do |out, _err|
           stdout << out
@@ -450,7 +451,7 @@ EOF
         assert_equal(Encoding::UTF_8, message.encoding)
 
         process = Subprocess::Process.new(['cat'], :stdin => Subprocess::PIPE, :stdout => Subprocess::PIPE)
-        stdout = ""
+        stdout = +""
         process.communicate(message) do |out, _err|
           stdout << out
         end


### PR DESCRIPTION
While running tests for https://github.com/sorbet/sorbet/pull/7778 I noticed some deprecation warnings coming from this gem.

Ruby 3.4 will have chilled string literals, as a first step toward frozen string literals becoming the default.

Ref: https://bugs.ruby-lang.org/issues/20205