### PR TITLE
Remove support for Ruby 2.5

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3]
+        ruby: [2.6, 2.7, 3.0, 3.1, 3.2, 3.3]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
CI is failing on Ruby 2.5 and it's giga old.